### PR TITLE
Modified go-netfilter-queue to support injecting new/modified packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ You can then use go-netfilter-queue to inspect the packets:
             }
     }
 
+To inject a new or modified packet in the place of the original packet, use:
+
+    p.SetVerdictWithPacket(netfilter.NF_ACCEPT, byte_slice)
+
+Instead of:
+
+    p.SetVerdict(netfilter.NF_ACCEPT)
+
 To undo the IPTables redirect. Run:
 
     iptables -D OUTPUT -p icmp -j NFQUEUE --queue-num 0

--- a/netfilter.h
+++ b/netfilter.h
@@ -27,29 +27,36 @@
 #include <linux/netfilter.h>
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-extern uint go_callback(int id, unsigned char* data, int len, u_int32_t idx);
+typedef struct {
+    uint verdict;
+    uint length;
+    unsigned char *data;
+} verdictContainer;
+
+extern void go_callback(int id, unsigned char* data, int len, u_int32_t idx, verdictContainer *vc);
 
 static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct nfq_data *nfa, void *cb_func){
     uint32_t id = -1;
     struct nfqnl_msg_packet_hdr *ph = NULL;
     unsigned char *buffer = NULL;
     int ret = 0;
-    int verdict = 0;
     u_int32_t idx;
+    verdictContainer vc;
 
     ph = nfq_get_msg_packet_hdr(nfa);
     id = ntohl(ph->packet_id);
 
     ret = nfq_get_payload(nfa, &buffer);
     idx = (uint32_t)((uintptr_t)cb_func);
-    verdict = go_callback(id, buffer, ret, idx);
 
-    return nfq_set_verdict(qh, id, verdict, 0, NULL);
+    go_callback(id, buffer, ret, idx, &vc);
+
+    return nfq_set_verdict(qh, id, vc.verdict, vc.length, vc.data);
 }
 
 static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, u_int16_t queue, u_int32_t idx)
 {
-  return nfq_create_queue(h, queue, &nf_callback, (void*)((uintptr_t)idx));
+    return nfq_create_queue(h, queue, &nf_callback, (void*)((uintptr_t)idx));
 }
 
 static inline void Run(struct nfq_handle *h, int fd)
@@ -63,5 +70,3 @@ static inline void Run(struct nfq_handle *h, int fd)
 }
 
 #endif
-
-


### PR DESCRIPTION
I'd like to upstream this. Please let me know if you have any questions about my mods. As referenced in the commit message, these patches were based on the (outdated, non-working) patches at:
https://github.com/david415/go-netfilter-queue

I essentially used that concept, but cleaned up the code quite a bit and made it more understandable.

Thanks,
Bill Katsak
