### PR TITLE
Close nfq.packets when Close() called

### DIFF
--- a/netfilter.go
+++ b/netfilter.go
@@ -168,6 +168,7 @@ func (nfq *NFQueue) Close() {
 	C.nfq_destroy_queue(nfq.qh)
 	C.nfq_close(nfq.h)
 	theTabeLock.Lock()
+	close(nfq.packets)
 	delete(theTable, nfq.idx)
 	theTabeLock.Unlock()
 }


### PR DESCRIPTION
`Close()` did not close the `nfq.packets` channel, which caused the program to go into an abnormal state