### PR TITLE
Allow out-of-order processing of packets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pietdevaere/go-netfilter-queue
+module github.com/AkihiroSuda/go-netfilter-queue
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/pietdevaere/go-netfilter-queue
+
+go 1.15
+
+require github.com/google/gopacket v1.1.19

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/netfilter.go
+++ b/netfilter.go
@@ -45,13 +45,10 @@ import (
 //Verdict for a packet
 type Verdict C.uint
 
-//Container for a verdict and (possibly) a modified packet (C side)
-type VerdictContainerC C.verdictContainer
-
 type NFPacket struct {
 	Packet gopacket.Packet
 	qh     *C.struct_nfq_q_handle
-	id     C.uint
+	id     C.uint32_t
 }
 
 //Set the verdict for the packet
@@ -186,7 +183,7 @@ func (nfq *NFQueue) run() {
 }
 
 //export go_callback
-func go_callback(queueId C.int, data *C.uchar, length C.int, idx uint32, vc *VerdictContainerC) {
+func go_callback(packetId C.uint32_t, data *C.uchar, length C.int, idx uint32, qh *C.struct_nfq_q_handle) {
 	xdata := C.GoBytes(unsafe.Pointer(data), length)
 
 	var packet gopacket.Packet
@@ -198,8 +195,8 @@ func go_callback(queueId C.int, data *C.uchar, length C.int, idx uint32, vc *Ver
 
 	p := NFPacket{
 		Packet: packet,
-		qh:     vc.qh,
-		id:     vc.id,
+		qh:     qh,
+		id:     packetId,
 	}
 
 	theTabeLock.RLock()

--- a/netfilter.h
+++ b/netfilter.h
@@ -29,15 +29,13 @@
 #include <linux/netfilter.h>
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
-typedef struct {
-    struct nfq_q_handle *qh;
-    uint id;
-    uint32_t verdict;
-    uint length;
-    unsigned char *data;
-} verdictContainer;
-
-extern void go_callback(int id, unsigned char* data, int len, u_int32_t idx, verdictContainer *vc);
+extern void go_callback(
+    uint32_t id,
+    unsigned char* data,
+    int len,
+    u_int32_t idx,
+    struct nfq_q_handle* qh
+);
 
 static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct nfq_data *nfa, void *cb_func){
     uint32_t id = -1;
@@ -45,7 +43,6 @@ static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct n
     unsigned char *buffer = NULL;
     int ret = 0;
     u_int32_t idx;
-    verdictContainer vc;
 
     ph = nfq_get_msg_packet_hdr(nfa);
     id = ntohl(ph->packet_id);
@@ -53,9 +50,7 @@ static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct n
     ret = nfq_get_payload(nfa, &buffer);
     idx = (uint32_t)((uintptr_t)cb_func);
 
-    vc.qh = qh;
-    vc.id = id;
-    go_callback(id, buffer, ret, idx, &vc);
+    go_callback(id, buffer, ret, idx, qh);
     return 0;
 }
 

--- a/netfilter.h
+++ b/netfilter.h
@@ -30,7 +30,9 @@
 #include <libnetfilter_queue/libnetfilter_queue.h>
 
 typedef struct {
-    uint verdict;
+    struct nfq_q_handle *qh;
+    uint id;
+    uint32_t verdict;
     uint length;
     unsigned char *data;
 } verdictContainer;
@@ -51,9 +53,10 @@ static int nf_callback(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg, struct n
     ret = nfq_get_payload(nfa, &buffer);
     idx = (uint32_t)((uintptr_t)cb_func);
 
+    vc.qh = qh;
+    vc.id = id;
     go_callback(id, buffer, ret, idx, &vc);
-
-    return nfq_set_verdict(qh, id, vc.verdict, vc.length, vc.data);
+    return 0;
 }
 
 static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, u_int16_t queue, u_int32_t idx)


### PR DESCRIPTION
I removed verdict containers and channels. Instead the information needed to call `nfq_set_verdict()` is now stored in the `NFPacket` struct, meaning that we can now call `nfq_set_verdict()` from golang at any point, instead of always calling it from the C side after the golang callback returned.

This also means that the golang callback can return before the decision for a packet is known, which makes it possible to process packets out of order. It also facilitates processing packets in multiple threads.