### PR TITLE
sys/types.h for u_intX_t types on alpine

### DIFF
--- a/netfilter.h
+++ b/netfilter.h
@@ -24,6 +24,7 @@
 #include <math.h>
 #include <unistd.h>
 #include <netinet/in.h>
+#include <sys/types.h>
 #include <linux/types.h>
 #include <linux/socket.h>
 #include <linux/netfilter.h>


### PR DESCRIPTION
Previously I saw this on alpine:
```
./netfilter.go:136:19: could not determine kind of name for C.CreateQueue
./netfilter.go:136:40: could not determine kind of name for C.u_int16_t
./netfilter.go:136:62: could not determine kind of name for C.u_int32_t
./netfilter.go:147:28: could not determine kind of name for C.u_int8_t
cgo:
gcc errors for preamble:
In file included from ./netfilter.go:30:
./netfilter.h:36:5: error: unknown type name 'u_int32_t'; did you mean 'uint32_t'?
   36 |     u_int32_t idx,
      |     ^~~~~~~~~
      |     uint32_t
./netfilter.h: In function 'nf_callback':
./netfilter.h:45:5: error: unknown type name 'u_int32_t'; did you mean 'uint32_t'?
   45 |     u_int32_t idx;
      |     ^~~~~~~~~
      |     uint32_t
./netfilter.h: At top level:
./netfilter.h:57:70: error: unknown type name 'u_int16_t'; did you mean 'uint16_t'?
   57 | static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, u_int16_t queue, u_int32_t idx)
      |                                                                      ^~~~~~~~~
      |                                                                      uint16_t
./netfilter.h:57:87: error: unknown type name 'u_int32_t'; did you mean 'uint32_t'?
   57 | static inline struct nfq_q_handle* CreateQueue(struct nfq_handle *h, u_int16_t queue, u_int32_t idx)
      |                                                                                       ^~~~~~~~~
      |
```