### PR TITLE
Reduce packet drops by using a larger channel

### DIFF
--- a/netfilter.go
+++ b/netfilter.go
@@ -128,7 +128,7 @@ func NewNFQueue(queueId uint16, maxPacketsInQueue uint32, packetSize uint32) (*N
 		return nil, fmt.Errorf("Error binding to AF_INET6 protocol family: %v\n", err)
 	}
 
-	nfq.packets = make(chan NFPacket)
+	nfq.packets = make(chan NFPacket, maxPacketsInQueue)
 	nfq.idx = uint32(time.Now().UnixNano())
 	theTabeLock.Lock()
 	theTable[nfq.idx] = &nfq.packets


### PR DESCRIPTION
I was seeing a lot of packet drops because the channel was full. Adding capacity to the channel fixes the problem for me.

(Thanks for writing this library, by the way!)